### PR TITLE
gemspec improvements

### DIFF
--- a/yard-sorbet.gemspec
+++ b/yard-sorbet.gemspec
@@ -5,16 +5,26 @@ require_relative 'lib/yard-sorbet/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'yard-sorbet'
-  spec.author = 'Douglas Eichelberger'
-  spec.files = `git ls-files`.strip.split(/\s+/)
-  spec.summary = 'Create YARD docs from Sorbet type signatures'
   spec.version = YARDSorbet::VERSION
+  spec.author = 'Douglas Eichelberger'
+  spec.email = 'dduugg@gmail.com'
+  spec.license = 'Apache-2.0'
+
+  spec.summary = 'Create YARD docs from Sorbet type signatures'
   spec.description = <<~DESC
     A YARD plugin that incorporates Sorbet type information
   DESC
-  spec.email = 'dduugg@gmail.com'
   spec.homepage = 'https://github.com/dduugg/yard-sorbet'
-  spec.license = 'Apache-2.0'
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['changelog_uri'] = 'https://github.com/dduugg/yard-sorbet/blob/master/CHANGELOG.md'
+
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(sorbet|spec)/}) }
+  end
+
   spec.add_development_dependency 'codecov', '~> 0.1.16'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
@@ -25,5 +35,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sorbet', '~> 0.5.5325'
   spec.add_runtime_dependency 'sorbet-runtime', '~> 0.5'
   spec.add_runtime_dependency 'yard', '~> 0.9'
-  spec.required_ruby_version = '>= 2.4.0'
 end


### PR DESCRIPTION
This consists of minor edits to the `gemspec` file. The primary motivation is to exclude the `sorbet` and `spec` dirs, reducing the size of the built gem from 258k to 14k. The `spec` settings and their ordering is now mostly consistent with the output of what `bundle gem` does.