### PR TITLE
Disable warning for T.attached_class

### DIFF
--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -40,7 +40,7 @@ module YARDSorbet::SigToYARD
       if children[0].source == 'T'
         t_method = IS_LEGACY_RUBY_VERSION ? children[1].source : children[2].source
         case t_method
-        when 'all', 'class_of', 'enum', 'noreturn', 'self_type', 'type_parameter', 'untyped'
+        when 'all', 'attached_class', 'class_of', 'enum', 'noreturn', 'self_type', 'type_parameter', 'untyped'
           # YARD doesn't have equivalent notions, so we just use the raw source
           [node.source]
         when 'any'

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -194,6 +194,9 @@ class VariousTypedSigs
   sig { returns(T.all(Foo, Bar)) }
   def call_T_all; end
 
+  sig { returns(T.attached_class) }
+  def call_T_attached_class; end
+
   sig { returns(T.class_of(String)) }
   def call_T_class_of; String; end
 

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -223,6 +223,11 @@ RSpec.describe YARDSorbet::SigHandler do
       expect(node.tag(:return).types).to eq(['T.all(Foo, Bar)'])
     end
 
+    it 'call_T_attached_class' do
+      node = YARD::Registry.at('VariousTypedSigs#call_T_attached_class')
+      expect(node.tag(:return).types).to eq(['T.attached_class'])
+    end
+
     it 'call_T_class_of' do
       node = YARD::Registry.at('VariousTypedSigs#call_T_class_of')
       expect(node.tag(:return).types).to eq(['T.class_of(String)'])


### PR DESCRIPTION
Usages of T.attached_class is currently producing a warning. As far as I know it doesn't have an equivalent YARD representation and can be included in this list instead of producing a warning.