### PR TITLE
Use info instead of warn

### DIFF
--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -27,7 +27,7 @@ module YARDSorbet::SigToYARD
         value_type = convert(children.last.children.last).join(', ')
         ["Hash{#{key_type} => #{value_type}}"]
       else
-        log.warn("Unsupported sig aref node #{node.source}")
+        log.info("Unsupported sig aref node #{node.source}")
         [node.source]
       end
     when :arg_paren


### PR DESCRIPTION
There is no way to support this case due to Yard limitations. Therefore we can reduce the severity of this message.