### PR TITLE
Fix warning for nested arrays with custom types

### DIFF
--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -28,7 +28,10 @@ module YARDSorbet::SigToYARD
         ["Hash{#{key_type} => #{value_type}}"]
       else
         log.info("Unsupported sig aref node #{node.source}")
-        [node.source]
+
+        collection_type = children.first.source.split('::').last
+        member_type = convert(children.last.children.first).join(', ')
+        ["#{collection_type}[#{member_type}]"]
       end
     when :arg_paren
       convert(children.first.children.first)

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -29,7 +29,7 @@ module YARDSorbet::SigToYARD
       else
         log.info("Unsupported sig aref node #{node.source}")
 
-        collection_type = children.first.source.split('::').last
+        collection_type = children.first.source
         member_type = children.last.source
         ["#{collection_type}[#{member_type}]"]
       end

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -30,7 +30,7 @@ module YARDSorbet::SigToYARD
         log.info("Unsupported sig aref node #{node.source}")
 
         collection_type = children.first.source.split('::').last
-        member_type = convert(children.last.children.first).join(', ')
+        member_type = children.last.source
         ["#{collection_type}[#{member_type}]"]
       end
     when :arg_paren

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -168,6 +168,9 @@ class CollectionSigs
   sig{params(arr: T::Array[Custom[String]]).void}
   def nested_custom_collection(arr); end
 
+  sig{params(arr: Custom[T.all(T.any(Foo, Bar), T::Array[String], T::Hash[Integer, Symbol])]).void}
+  def custom_collection_with_inner_nodes(arr); end
+
   sig {returns([String, Integer])}
   def fixed_array; ['', 0]; end
 

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -162,6 +162,12 @@ class CollectionSigs
   sig {returns(T::Hash[String, Symbol])}
   def hash_method; end
 
+  sig{params(arr: Custom[String]).void}
+  def custom_collection(arr); end
+
+  sig{params(arr: T::Array[Custom[String]]).void}
+  def nested_custom_collection(arr); end
+
   sig {returns([String, Integer])}
   def fixed_array; ['', 0]; end
 

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -191,6 +191,18 @@ RSpec.describe YARDSorbet::SigHandler do
       expect(node.tag(:return).types).to eq(['Hash{String => Symbol}'])
     end
 
+    it 'custom collection' do
+      node = YARD::Registry.at('CollectionSigs#custom_collection')
+      param_tag = node.tags.find { |t| t.name == 'arr' }
+      expect(param_tag.types).to eq(['Custom[String]'])
+    end
+
+    it 'nested custom collection' do
+      node = YARD::Registry.at('CollectionSigs#nested_custom_collection')
+      param_tag = node.tags.find { |t| t.name == 'arr' }
+      expect(param_tag.types).to eq(['Array<Custom[String]>'])
+    end
+
     it 'fixed Array' do
       node = YARD::Registry.at('CollectionSigs#fixed_array')
       expect(node.tag(:return).types).to eq(['Array(String, Integer)'])

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -203,6 +203,12 @@ RSpec.describe YARDSorbet::SigHandler do
       expect(param_tag.types).to eq(['Array<Custom[String]>'])
     end
 
+    it 'custom collection with inner nodes' do
+      node = YARD::Registry.at('CollectionSigs#custom_collection_with_inner_nodes')
+      param_tag = node.tags.find { |t| t.name == 'arr' }
+      expect(param_tag.types).to eq(['Custom[T.all(T.any(Foo, Bar), T::Array[String], T::Hash[Integer, Symbol])]'])
+    end
+
     it 'fixed Array' do
       node = YARD::Registry.at('CollectionSigs#fixed_array')
       expect(node.tag(:return).types).to eq(['Array(String, Integer)'])


### PR DESCRIPTION
I've been encountering warnings such as:
`@param tag has unknown parameter name: ]` or `@param tag has unknown parameter name: ,`

I noticed that this only occurs with signatures that contain nested custom types such as `T::Array[Custom[String]]`.

After debugging I noticed that the inner node `Custom[String]` is actually parsed as `Custom[String]]` within [Yard parser](https://github.com/lsegal/yard/blob/7104257bef486424d77eddd2f1ffc6834d7ee090/lib/yard/parser/ruby/ast_node.rb#L198-L201).

So while converting `T::Array[Custom[String]]` node we correctly convert the outer `T::Array` and call `convert` with its children, the inner `Custom[String]]` node.  Then we enter the `else` branch of the `:aref` case and return `Custom[String]]` which results in the warning.

I noticed that the parser returns an extra `]` even for `T::Array[String]` signature. This case is not outputting a warning because we extract the relevant information [here](https://github.com/dduugg/yard-sorbet/blob/7a1cb1dbe0838dbc83b0b6b2c10930cd07fc6e20/lib/yard-sorbet/sig_to_yard.rb#L22-L24).

I wasn't 100% sure how to fix this so I'm open to suggestions. Currently I opted for a similar approach as the `T::Array` case. As you can see from the test cases for an input of `T::Array[Custom[String]]` we would output `Array<Custom[String]>` .

This could be wrong if we encountered "non array" signatures inside that `else` block. I'm curious if that is a possibility given we are in a `:aref` node