### PR TITLE
Fix nested generic collection parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Bug fixes
 
-* [#12](https://github.com/dduugg/yard-sorbet/pull/12): Fix parsing of recusrive custom paremeterized types.
+* [#12](https://github.com/dduugg/yard-sorbet/pull/12): Fix parsing of recursive custom paremeterized types.
 * [#9](https://github.com/dduugg/yard-sorbet/pull/9): Remove warning for use of `T.attached_class`.
 * [#11](https://github.com/dduugg/yard-sorbet/pull/11): Fix parsing of custom parameterized types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
 
 ### Bug fixes
 
-* [#12](https://github.com/dduugg/yard-sorbet/pull/12): Fix parsing of recursive custom paremeterized types.
 * [#9](https://github.com/dduugg/yard-sorbet/pull/9): Remove warning for use of `T.attached_class`.
 * [#11](https://github.com/dduugg/yard-sorbet/pull/11): Fix parsing of custom parameterized types.
+* [#12](https://github.com/dduugg/yard-sorbet/pull/12): Fix parsing of recursive custom paremeterized types.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * [#9](https://github.com/dduugg/yard-sorbet/pull/9): Remove warning for use of `T.attached_class`.
 * [#11](https://github.com/dduugg/yard-sorbet/pull/11): Fix parsing of custom parameterized types.
-* [#12](https://github.com/dduugg/yard-sorbet/pull/12): Fix parsing of recursive custom paremeterized types.
+* [#12](https://github.com/dduugg/yard-sorbet/pull/12): Fix parsing of recursive custom parameterized types.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 
+* [#12](https://github.com/dduugg/yard-sorbet/pull/12): Fix parsing of recusrive custom paremeterized types.
 * [#9](https://github.com/dduugg/yard-sorbet/pull/9): Remove warning for use of `T.attached_class`.
 * [#11](https://github.com/dduugg/yard-sorbet/pull/11): Fix parsing of custom parameterized types.
 

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -99,8 +99,8 @@ module YARDSorbet::SigToYARD
     collection_type = node.children.first.source
 
     member_type = node.children.last.children
-      .map { |child| build_generic_type(child) }
-      .join(", ")
+                      .map { |child| build_generic_type(child) }
+                      .join(', ')
 
     "#{collection_type}[#{member_type}]"
   end

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -97,7 +97,6 @@ module YARDSorbet::SigToYARD
     return node.source if node.children.empty? || node.type != :aref
 
     collection_type = node.children.first.source
-
     member_type = node.children.last.children
                       .map { |child| build_generic_type(child) }
                       .join(', ')

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -97,11 +97,10 @@ module YARDSorbet::SigToYARD
     return node.source if node.children.empty? || node.type != :aref
 
     collection_type = node.children.first.source
-    member_types = []
-    node.children.last.children.each do |child|
-      member_types << build_generic_type(child)
-    end
-    member_type = member_types.join(", ")
+
+    member_type = node.children.last.children
+      .map { |child| build_generic_type(child) }
+      .join(", ")
 
     "#{collection_type}[#{member_type}]"
   end

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -28,10 +28,7 @@ module YARDSorbet::SigToYARD
         ["Hash{#{key_type} => #{value_type}}"]
       else
         log.info("Unsupported sig aref node #{node.source}")
-
-        collection_type = children.first.source
-        member_type = children.last.source
-        ["#{collection_type}[#{member_type}]"]
+        [fix_generic_aref(node)]
       end
     when :arg_paren
       convert(children.first.children.first)
@@ -94,5 +91,11 @@ module YARDSorbet::SigToYARD
       log.warn("Unsupported sig #{node.type} node #{node.source}")
       [node.source]
     end
+  end
+
+  def self.fix_generic_aref(node)
+    return node.source if node.children.empty? || node.type != :aref
+
+    "#{node.children.first.source}[#{fix_generic_aref(node.children.last.children.first)}]"
   end
 end

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -93,9 +93,16 @@ module YARDSorbet::SigToYARD
     end
   end
 
-  def self.fix_generic_aref(node)
+  def self.build_generic_type(node)
     return node.source if node.children.empty? || node.type != :aref
 
-    "#{node.children.first.source}[#{fix_generic_aref(node.children.last.children.first)}]"
+    collection_type = node.children.first.source
+    member_types = []
+    node.children.last.children.each do |child|
+      member_types << build_generic_type(child)
+    end
+    member_type = member_types.join(", ")
+
+    "#{collection_type}[#{member_type}]"
   end
 end

--- a/lib/yard-sorbet/sig_to_yard.rb
+++ b/lib/yard-sorbet/sig_to_yard.rb
@@ -28,7 +28,7 @@ module YARDSorbet::SigToYARD
         ["Hash{#{key_type} => #{value_type}}"]
       else
         log.info("Unsupported sig aref node #{node.source}")
-        [fix_generic_aref(node)]
+        [build_generic_type(node)]
       end
     when :arg_paren
       convert(children.first.children.first)

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -165,7 +165,7 @@ class CollectionSigs
   sig{params(arr: Custom[String]).void}
   def custom_collection(arr); end
 
-  sig{params(arr: T::Array[Custom1[Custom2[String]]]).void}
+  sig{params(arr: T::Array[Custom1[Custom2[String, Integer, T::Boolean], T.any(Custom3[String], Custom4[Integer])]]).void}
   def nested_custom_collection(arr); end
 
   sig{params(arr: Custom[T.all(T.any(Foo, Bar), T::Array[String], T::Hash[Integer, Symbol])]).void}

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -165,7 +165,7 @@ class CollectionSigs
   sig{params(arr: Custom[String]).void}
   def custom_collection(arr); end
 
-  sig{params(arr: T::Array[Custom[String]]).void}
+  sig{params(arr: T::Array[Custom1[Custom2[String]]]).void}
   def nested_custom_collection(arr); end
 
   sig{params(arr: Custom[T.all(T.any(Foo, Bar), T::Array[String], T::Hash[Integer, Symbol])]).void}

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe YARDSorbet::SigHandler do
     it 'nested custom collection' do
       node = YARD::Registry.at('CollectionSigs#nested_custom_collection')
       param_tag = node.tags.find { |t| t.name == 'arr' }
-      expect(param_tag.types).to eq(['Array<Custom[String]>'])
+      expect(param_tag.types).to eq(['Array<Custom1[Custom2[String]]>'])
     end
 
     it 'custom collection with inner nodes' do

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe YARDSorbet::SigHandler do
     it 'nested custom collection' do
       node = YARD::Registry.at('CollectionSigs#nested_custom_collection')
       param_tag = node.tags.find { |t| t.name == 'arr' }
-      expect(param_tag.types).to eq(['Array<Custom1[Custom2[String]]>'])
+      expect(param_tag.types).to eq(['Array<Custom1[Custom2[String, Integer, T::Boolean], T.any(Custom3[String], Custom4[Integer])]>'])
     end
 
     it 'custom collection with inner nodes' do


### PR DESCRIPTION
This is a continuation of the same issue this PR addressed: https://github.com/dduugg/yard-sorbet/pull/11.

That was a limited fix in that it doesn't fix it recursively and the issue can be seen in lower levels of the tree, ie. 
`sig{params(arr: T::Array[Custom1[Custom2[String]]]).void}` would still result in a warning and a parameter parsing error.

With @paracycle, we added a `fix_generic_aref(node)` method that enables us to traverse only `aref` nodes and handle them accordingly. We still avoid calling `convert` on internals of a generic type but we are able to get around the parsing error.

Extended the current test to represent this issue.