### PR TITLE
Fix pending struct handler tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 
+* [#13](https://github.com/dduugg/yard-sorbet/pull/13): Fix pending struct handler tests.
 * [#9](https://github.com/dduugg/yard-sorbet/pull/9): Remove warning for use of `T.attached_class`.
 * [#11](https://github.com/dduugg/yard-sorbet/pull/11): Fix parsing of custom parameterized types.
 

--- a/spec/yard_sorbet/struct_handler_spec.rb
+++ b/spec/yard_sorbet/struct_handler_spec.rb
@@ -14,34 +14,34 @@ RSpec.describe YARDSorbet::StructHandler do
   end
 
   describe 'constructor' do
-    T.unsafe(it('has the appropriate parameters')) do
+    it('has the appropriate parameters') do
       node = YARD::Registry.at('PersonStruct#initialize')
       expect(node.parameters).to eq([['name:', nil], ['age:', nil], ['optional:', 'nil'], ['mystery:', nil]])
     end
 
-    T.unsafe(it('uses the docstring from an explicit initializer')) do
+    it('uses the docstring from an explicit initializer') do
       node = YARD::Registry.at('SpecializedPersonStruct#initialize')
       expect(node.docstring).to eq('This is a special intializer')
     end
   end
 
   describe 'attributes' do
-    T.unsafe(it('creates accessor method docs')) do
+    it('creates accessor method docs') do
       node = YARD::Registry.at('PersonStruct#optional')
       expect(node.tag(:return).types).to eq(%w[String nil])
     end
 
-    T.unsafe(it('attaches the docstring to the accessor')) do
+    it('attaches the docstring to the accessor') do
       node = YARD::Registry.at('PersonStruct#age')
       expect(node.docstring).to eq('An age')
     end
 
-    T.unsafe(it('creates a docstring if it does not exist')) do
+    it('creates a docstring if it does not exist') do
       node = YARD::Registry.at('PersonStruct#mystery')
       expect(node.docstring).to eq('Returns the value of attribute +mystery+.')
     end
 
-    T.unsafe(it('handles default values appropriately')) do
+    it('handles default values appropriately') do
       node = YARD::Registry.at('DefaultPersonStruct#initialize')
       expect(node.parameters).to eq([['defaulted:', "'hello'"]])
     end


### PR DESCRIPTION
`T.unsafe` calls are unnecessary due to Minitest support using a [rewriter in Sorbet](https://github.com/sorbet/sorbet/blob/510115486d52c539f7cce8a0e537ab7864e02929/rewriter/Minitest.h#L7)

It caused these tests to be skipped as can be seen in previous CI runs: https://travis-ci.com/github/dduugg/yard-sorbet/jobs/446087849#L371