### PR TITLE
Remove redundant call to register

### DIFF
--- a/lib/yard-sorbet/struct_handler.rb
+++ b/lib/yard-sorbet/struct_handler.rb
@@ -31,6 +31,8 @@ class YARDSorbet::StructHandler < YARD::Handlers::Ruby::Base
     object = MethodObject.new(namespace, name, scope)
     object.source = source
 
+    register(object.source) # TODO: remove
+
     reader_docstring = doc.empty? ? "Returns the value of attribute +#{name}+." : doc
     docstring = YARD::DocstringParser.new.parse(reader_docstring).to_docstring
     docstring.add_tag(YARD::Tags::Tag.new(:return, '', types))

--- a/lib/yard-sorbet/struct_handler.rb
+++ b/lib/yard-sorbet/struct_handler.rb
@@ -31,8 +31,6 @@ class YARDSorbet::StructHandler < YARD::Handlers::Ruby::Base
     object = MethodObject.new(namespace, name, scope)
     object.source = source
 
-    register(object)
-
     reader_docstring = doc.empty? ? "Returns the value of attribute +#{name}+." : doc
     docstring = YARD::DocstringParser.new.parse(reader_docstring).to_docstring
     docstring.add_tag(YARD::Tags::Tag.new(:return, '', types))

--- a/lib/yard-sorbet/struct_handler.rb
+++ b/lib/yard-sorbet/struct_handler.rb
@@ -31,8 +31,6 @@ class YARDSorbet::StructHandler < YARD::Handlers::Ruby::Base
     object = MethodObject.new(namespace, name, scope)
     object.source = source
 
-    register(object.source) # TODO: remove
-
     reader_docstring = doc.empty? ? "Returns the value of attribute +#{name}+." : doc
     docstring = YARD::DocstringParser.new.parse(reader_docstring).to_docstring
     docstring.add_tag(YARD::Tags::Tag.new(:return, '', types))

--- a/spec/yard_sorbet/struct_handler_spec.rb
+++ b/spec/yard_sorbet/struct_handler_spec.rb
@@ -3,13 +3,26 @@
 
 require 'yard'
 
+module Refinement
+  refine YARDSorbet::StructHandler do
+    prepend(Module.new do
+      def register(*objects)
+        raise "Redundant call"
+      end
+    end)
+  end
+end
+
+using Refinement
+
 RSpec.describe YARDSorbet::StructHandler do
+  path = File.join(
+    File.expand_path('../data', __dir__),
+    'struct_handler.rb.txt'
+  )
+
   before do
     YARD::Registry.clear
-    path = File.join(
-      File.expand_path('../data', __dir__),
-      'struct_handler.rb.txt'
-    )
     YARD::Parser::SourceParser.parse(path)
   end
 
@@ -44,6 +57,11 @@ RSpec.describe YARDSorbet::StructHandler do
     it('handles default values appropriately') do
       node = YARD::Registry.at('DefaultPersonStruct#initialize')
       expect(node.parameters).to eq([['defaulted:', "'hello'"]])
+    end
+
+    it('does not trigger a redundant call to `register`') do
+      YARD::Registry.clear
+      YARD::Parser::SourceParser.parse(path)
     end
   end
 end

--- a/spec/yard_sorbet/struct_handler_spec.rb
+++ b/spec/yard_sorbet/struct_handler_spec.rb
@@ -4,12 +4,13 @@
 require 'yard'
 
 RSpec.describe YARDSorbet::StructHandler do
-  before do
-    YARD::Registry.clear
-    path = File.join(
+  path = File.join(
       File.expand_path('../data', __dir__),
       'struct_handler.rb.txt'
     )
+
+  before do
+    YARD::Registry.clear
     YARD::Parser::SourceParser.parse(path)
   end
 
@@ -44,6 +45,12 @@ RSpec.describe YARDSorbet::StructHandler do
     it('handles default values appropriately') do
       node = YARD::Registry.at('DefaultPersonStruct#initialize')
       expect(node.parameters).to eq([['defaulted:', "'hello'"]])
+    end
+
+    it('does not trigger a redundant call to `register`') do
+      YARD::Registry.clear
+      expect_any_instance_of(YARDSorbet::StructHandler).to_not receive(:register)
+      YARD::Parser::SourceParser.parse(path)
     end
   end
 end

--- a/spec/yard_sorbet/struct_handler_spec.rb
+++ b/spec/yard_sorbet/struct_handler_spec.rb
@@ -4,13 +4,12 @@
 require 'yard'
 
 RSpec.describe YARDSorbet::StructHandler do
-  path = File.join(
+  before do
+    YARD::Registry.clear
+    path = File.join(
       File.expand_path('../data', __dir__),
       'struct_handler.rb.txt'
     )
-
-  before do
-    YARD::Registry.clear
     YARD::Parser::SourceParser.parse(path)
   end
 
@@ -45,12 +44,6 @@ RSpec.describe YARDSorbet::StructHandler do
     it('handles default values appropriately') do
       node = YARD::Registry.at('DefaultPersonStruct#initialize')
       expect(node.parameters).to eq([['defaulted:', "'hello'"]])
-    end
-
-    it('does not trigger a redundant call to `register`') do
-      YARD::Registry.clear
-      expect_any_instance_of(YARDSorbet::StructHandler).to_not receive(:register)
-      YARD::Parser::SourceParser.parse(path)
     end
   end
 end

--- a/spec/yard_sorbet/struct_handler_spec.rb
+++ b/spec/yard_sorbet/struct_handler_spec.rb
@@ -3,18 +3,6 @@
 
 require 'yard'
 
-module Refinement
-  refine YARDSorbet::StructHandler do
-    prepend(Module.new do
-      def register(*objects)
-        raise "Redundant call"
-      end
-    end)
-  end
-end
-
-using Refinement
-
 RSpec.describe YARDSorbet::StructHandler do
   path = File.join(
     File.expand_path('../data', __dir__),
@@ -61,6 +49,7 @@ RSpec.describe YARDSorbet::StructHandler do
 
     it('does not trigger a redundant call to `register`') do
       YARD::Registry.clear
+      expect_any_instance_of(described_class).not_to receive(:register) # rubocop:disable RSpec/AnyInstance
       YARD::Parser::SourceParser.parse(path)
     end
   end


### PR DESCRIPTION
This call to [register](https://github.com/lsegal/yard/blob/7104257bef486424d77eddd2f1ffc6834d7ee090/lib/yard/handlers/base.rb#L407) method seems to be redundant for usages of this handler as we are already copying over information from the original `statement`. it's also triggering warnings when used with this callback that ensures top namespace documentations are not overridden https://github.com/lsegal/yard/issues/1173#issuecomment-400428506

