### PR TITLE
Fixes handling of methods that contain a comment on method definition line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#9](https://github.com/dduugg/yard-sorbet/pull/9): Remove warning for use of `T.attached_class`.
 * [#11](https://github.com/dduugg/yard-sorbet/pull/11): Fix parsing of custom parameterized types.
 * [#12](https://github.com/dduugg/yard-sorbet/pull/12): Fix parsing of recursive custom parameterized types.
+* [#17](https://github.com/dduugg/yard-sorbet/pull/17): Fix docstrings for methods that contain a comment on method definition line
 
 ### Changes
 

--- a/lib/yard-sorbet/sig_handler.rb
+++ b/lib/yard-sorbet/sig_handler.rb
@@ -36,7 +36,7 @@ class YARDSorbet::SigHandler < YARD::Handlers::Ruby::Base
 
   sig { params(next_statement: T.nilable(YARD::Parser::Ruby::AstNode)).returns(T::Boolean) }
   private def processable_method?(next_statement)
-    %i[def defs command].include?(next_statement&.type) && !T.must(next_statement).docstring
+    %i[def defs command].include?(next_statement&.type)
   end
 
   sig do

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -108,8 +108,14 @@ class SigReturn
   sig {void}
   def void_method; end
 
-  sig { void }
+  # method definition contains comment
+  sig {void}
   def method_definition_contains_comment # rubocop:disable ...
+  end
+
+  # class method definition contains comment
+  sig {void}
+  def self.class_method_definition_contains_comment # rubocop:disable ...
   end
 end
 

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -107,6 +107,10 @@ class SigReturn
 
   sig {void}
   def void_method; end
+
+  sig { void }
+  def method_definition_contains_comment # rubocop:disable ...
+  end
 end
 
 class SigAbstract

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -120,6 +120,13 @@ RSpec.describe YARDSorbet::SigHandler do
     it 'parses comments on the method definition line' do
       node = YARD::Registry.at('SigReturn#method_definition_contains_comment')
       expect(node.tag(:return).types).to eq(['void'])
+      expect(node.docstring).to eq('method definition contains comment')
+    end
+
+    it 'parses comments on the class method definition line' do
+      node = YARD::Registry.at('SigReturn.class_method_definition_contains_comment')
+      expect(node.tag(:return).types).to eq(['void'])
+      expect(node.docstring).to eq('class method definition contains comment')
     end
 
     it 'with abstract sig' do

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -117,6 +117,11 @@ RSpec.describe YARDSorbet::SigHandler do
       expect(node.tag(:return).types).to eq(['void'])
     end
 
+    it 'parses comments on the method definition line' do
+      node = YARD::Registry.at('SigReturn#method_definition_contains_comment')
+      expect(node.tag(:return).types).to eq(['void'])
+    end
+
     it 'with abstract sig' do
       node = YARD::Registry.at('SigAbstract#one')
       expect(node.tag(:abstract).text).to eq('')


### PR DESCRIPTION
Before when we saw a method that contained a comment on the same line as its method definition the method was deemed unprocessable and was skipped. As a result any signatures or documentation on the method would be replaced by the comment. 

This commit removes an extraneous check that deems the method unprocessable.

