### PR TITLE
Test command statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#17](https://github.com/dduugg/yard-sorbet/pull/17): Fix docstrings for methods that contain a comment on method definition line
+
 ### Changes
 
 * [#16](https://github.com/dduugg/yard-sorbet/pull/16): Enforce strict typing in non-spec code.
@@ -19,7 +23,6 @@
 * [#9](https://github.com/dduugg/yard-sorbet/pull/9): Remove warning for use of `T.attached_class`.
 * [#11](https://github.com/dduugg/yard-sorbet/pull/11): Fix parsing of custom parameterized types.
 * [#12](https://github.com/dduugg/yard-sorbet/pull/12): Fix parsing of recursive custom parameterized types.
-* [#17](https://github.com/dduugg/yard-sorbet/pull/17): Fix docstrings for methods that contain a comment on method definition line
 
 ### Changes
 

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -84,6 +84,10 @@ module Module
 end
 
 class SigReturn
+  # attr has trailing comment
+  sig {returns(String)}
+  attr_reader :attr_contains_comment # rubocop:disable ...
+
   sig {returns(Integer)}
   def one; 1; end
 

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -117,13 +117,19 @@ RSpec.describe YARDSorbet::SigHandler do
       expect(node.tag(:return).types).to eq(['void'])
     end
 
-    it 'parses comments on the method definition line' do
+    it 'with trailing comment on attr declaration' do
+      node = YARD::Registry.at('SigReturn#attr_contains_comment')
+      expect(node.tag(:return).types).to eq(['String'])
+      expect(node.docstring).to eq('attr has trailing comment')
+    end
+
+    it 'with trailing comment on the method definition line' do
       node = YARD::Registry.at('SigReturn#method_definition_contains_comment')
       expect(node.tag(:return).types).to eq(['void'])
       expect(node.docstring).to eq('method definition contains comment')
     end
 
-    it 'parses comments on the class method definition line' do
+    it 'with trailing comment on the class method definition line' do
       node = YARD::Registry.at('SigReturn.class_method_definition_contains_comment')
       expect(node.tag(:return).types).to eq(['void'])
       expect(node.docstring).to eq('class method definition contains comment')


### PR DESCRIPTION
Adds a test for `command` types and fixes the changelog entry (0.1.0 has already been released).