### PR TITLE
Remove default_checked_level

### DIFF
--- a/lib/yard-sorbet.rb
+++ b/lib/yard-sorbet.rb
@@ -4,8 +4,6 @@
 require 'sorbet-runtime'
 require 'yard'
 
-T::Configuration.default_checked_level = :tests
-
 # top-level namespace
 module YARDSorbet; end
 


### PR DESCRIPTION
Configuring the default_checked_level in a gem could cause problems if it's loaded explicitly during runtime of the application. It can be too late and throw a `RuntimeError: Set the default checked level earlier. There are already some methods whose sig blocks have evaluated which would not be affected by the new default.`

`default_checked_level` brings us minimal runtime performance increase so I believe it's safe to remove and follow the applications' configuration.