### PR TITLE
feat(StructHandler): support `prop` declarations

### DIFF
--- a/lib/yard-sorbet/struct_handler.rb
+++ b/lib/yard-sorbet/struct_handler.rb
@@ -1,12 +1,12 @@
 # typed: strict
 # frozen_string_literal: true
 
-# Handle all `const` calls, creating accessor methods, and compiles them for later usage at the class level
+# Handles all `const`/`prop` calls, creating accessor methods, and compiles them for later usage at the class level
 # in creating a constructor
 class YARDSorbet::StructHandler < YARD::Handlers::Ruby::Base
   extend T::Sig
 
-  handles method_call(:const)
+  handles method_call(:const), method_call(:prop)
   namespace_only
 
   sig { void }
@@ -41,10 +41,14 @@ class YARDSorbet::StructHandler < YARD::Handlers::Ruby::Base
 
     # Register the object explicitly as an attribute
     namespace.attributes[scope][name][:read] = object
+
+    # While `const` attributes are immutable, `prop` attributes may be reassigned.
+    method_name = statement.method_name.source
+    namespace.attributes[scope][name][:write] = object if method_name == 'prop'
   end
 end
 
-# Class-level handler that folds all `const` declarations into the constructor documentation
+# Class-level handler that folds all `const` and `prop` declarations into the constructor documentation
 # this needs to be injected as a module otherwise the default Class handler will overwrite documentation
 module YARDSorbet::StructClassHandler
   extend T::Sig

--- a/spec/data/struct_handler.rb.txt
+++ b/spec/data/struct_handler.rb.txt
@@ -6,6 +6,8 @@ class PersonStruct < T:Struct
   const :age, Integer
   # An optional
   const :optional, T.nilable(String)
+  # A writable
+  prop :writable, String
   const :mystery, T.untyped
 end
 

--- a/spec/yard_sorbet/struct_handler_spec.rb
+++ b/spec/yard_sorbet/struct_handler_spec.rb
@@ -17,7 +17,15 @@ RSpec.describe YARDSorbet::StructHandler do
   describe 'constructor' do
     it('has the appropriate parameters') do
       node = YARD::Registry.at('PersonStruct#initialize')
-      expect(node.parameters).to eq([['name:', nil], ['age:', nil], ['optional:', 'nil'], ['mystery:', nil]])
+      expect(node.parameters).to eq(
+        [
+          ['name:', nil],
+          ['age:', nil],
+          ['optional:', 'nil'],
+          ['writable:', nil],
+          ['mystery:', nil]
+        ]
+      )
     end
 
     it('uses the docstring from an explicit initializer') do
@@ -45,6 +53,16 @@ RSpec.describe YARDSorbet::StructHandler do
     it('handles default values appropriately') do
       node = YARD::Registry.at('DefaultPersonStruct#initialize')
       expect(node.parameters).to eq([['defaulted:', "'hello'"]])
+    end
+
+    it('marks `const` attributes read-only') do
+      node = YARD::Registry.at('PersonStruct#age')
+      expect(node.writer?).to eq(false)
+    end
+
+    it('does not mark `prop` attributes read-only') do
+      node = YARD::Registry.at('PersonStruct#writable')
+      expect(node.writer?).to eq(true)
     end
 
     it('does not trigger a redundant call to `register`') do


### PR DESCRIPTION
Fixes https://github.com/dduugg/yard-sorbet/issues/15

We use `prop` pretty heavily in our code at [Alto](https://alto.com/), and I would love to adopt this plugin to enhance our generated docs.

As far as I can tell, the difference is that `prop` is writable where `const` is not, and we can convince the doc generator that this is the case by _also_ setting the `:write` value in the struct attribute definition.

The generated docs for our example `PersonStruct` look like this, after this change:

<img width="1333" alt="Screen Shot 2021-03-29 at 12 24 28 PM" src="https://user-images.githubusercontent.com/1302133/112888932-d1d13480-9089-11eb-9ccb-762e24acdae0.png">
