### PR TITLE
fix: strip leading colon from reserved words in struct props

### DIFF
--- a/lib/yard-sorbet/struct_handler.rb
+++ b/lib/yard-sorbet/struct_handler.rb
@@ -12,7 +12,12 @@ class YARDSorbet::StructHandler < YARD::Handlers::Ruby::Base
   sig { void }
   def process
     # Store the property for use in the constructor definition
-    name = statement.parameters[0].jump(:ident).source
+    name = statement.parameters[0].jump(
+      :ident, # handles most "normal" identifiers
+      :kw,    # handles prop names using reserved words like `end` or `def`
+      :const  # handles capitalized prop names like Foo
+    ).source
+
     doc = statement.docstring.to_s
     source = statement.source
     types = YARDSorbet::SigToYARD.convert(statement.parameters[1])

--- a/spec/data/struct_handler.rb.txt
+++ b/spec/data/struct_handler.rb.txt
@@ -25,3 +25,10 @@ class DefaultPersonStruct < T::Struct
   # This has a default
   const :defaulted, String, default: 'hello'
 end
+
+# Symbols that will cause the ruby lexer to capture something other than an :ident
+# @see https://bugs.ruby-lang.org/issues/6306
+class ExceptionalPersonStruct < T::Struct
+  const :end, String
+  const :Foo, String
+end

--- a/spec/yard_sorbet/struct_handler_spec.rb
+++ b/spec/yard_sorbet/struct_handler_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe YARDSorbet::StructHandler do
       node = YARD::Registry.at('SpecializedPersonStruct#initialize')
       expect(node.docstring).to eq('This is a special intializer')
     end
+
+    it('handles exceptional prop names') do
+      node = YARD::Registry.at('ExceptionalPersonStruct#initialize')
+      expect(node.parameters).to eq(
+        [
+          ['end:', nil],
+          ['Foo:', nil]
+        ]
+      )
+    end
   end
 
   describe 'attributes' do


### PR DESCRIPTION
We have a struct that looks something like this:

```
TimeRange < T::Struct
  prop :start, Time
  prop :end, Time
end
```

yard-sorbet generates a signature for this that looks like this:

<img width="1425" alt="Screen Shot 2021-04-27 at 10 00 33 AM" src="https://user-images.githubusercontent.com/1302133/116282295-6ee1c480-a73f-11eb-9efe-ed6ca7ddc59e.png">

worse yet, it generates a warning that causes our poor sensitive build to break:

```
[warn]: @param tag has unknown parameter name: :end
```

This PR proposes to strip off leading colons from prop names, on the assumption that nobody is writing prop names like `const :':myprop'`.