### PR TITLE
Add T::Enum handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#43](https://github.com/dduugg/yard-sorbet/issues/43) Add `T::Enum` support
+
 ### Bug fixes
 
 * [#41](https://github.com/dduugg/yard-sorbet/issues/41) Fix superfluous return type of boolean method definitions with inline modifiers

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 A YARD [plugin](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md#Plugin_Support) that parses Sorbet type annotations
 
+## Features
+- Attaches existing documentation to methods and attributs that follow `sig` declarations. (This information is otherwise discarded.)
+- Translates `sig` type signatures into corresponding YARD tags
+- Generates method definitions from `T::Struct` fields
+- Generates constant definitions from `T::Enum` enums
+
 ## Install
 
 ```shell

--- a/lib/yard-sorbet.rb
+++ b/lib/yard-sorbet.rb
@@ -8,6 +8,7 @@ require 'yard'
 module YARDSorbet; end
 
 require_relative 'yard-sorbet/directives'
+require_relative 'yard-sorbet/enums_handler'
 require_relative 'yard-sorbet/node_utils'
 require_relative 'yard-sorbet/sig_handler'
 require_relative 'yard-sorbet/sig_to_yard'

--- a/lib/yard-sorbet/enums_handler.rb
+++ b/lib/yard-sorbet/enums_handler.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-# Handles all +enums+ calls, registering them as constants
+# Handle +enums+ calls, registering enum values as constants
 class YARDSorbet::EnumsHandler < YARD::Handlers::Ruby::Base
   extend T::Sig
 
@@ -10,5 +10,14 @@ class YARDSorbet::EnumsHandler < YARD::Handlers::Ruby::Base
 
   sig { void }
   def process
+    statement.traverse do |node|
+      if node.type == :assign
+        register YARD::CodeObjects::ConstantObject.new(namespace, node.first.source) do |obj|
+          obj.docstring = node.docstring
+          obj.source = node
+          obj.value = node.last.source
+        end
+      end
+    end
   end
 end

--- a/lib/yard-sorbet/enums_handler.rb
+++ b/lib/yard-sorbet/enums_handler.rb
@@ -1,0 +1,14 @@
+# typed: strict
+# frozen_string_literal: true
+
+# Handles all +enums+ calls, registering them as constants
+class YARDSorbet::EnumsHandler < YARD::Handlers::Ruby::Base
+  extend T::Sig
+
+  handles method_call(:enums)
+  namespace_only
+
+  sig { void }
+  def process
+  end
+end

--- a/lib/yard-sorbet/enums_handler.rb
+++ b/lib/yard-sorbet/enums_handler.rb
@@ -11,7 +11,7 @@ class YARDSorbet::EnumsHandler < YARD::Handlers::Ruby::Base
   sig { void }
   def process
     statement.traverse do |node|
-      if node.type == :assign
+      if const_assign_node?(node)
         register YARD::CodeObjects::ConstantObject.new(namespace, node.first.source) do |obj|
           obj.docstring = node.docstring
           obj.source = node
@@ -19,5 +19,10 @@ class YARDSorbet::EnumsHandler < YARD::Handlers::Ruby::Base
         end
       end
     end
+  end
+
+  sig { params(node: YARD::Parser::Ruby::AstNode).returns(T::Boolean) }
+  def const_assign_node?(node)
+    node.type == :assign && node.children.first.children.first.type == :const
   end
 end

--- a/spec/data/enums_handler.rb
+++ b/spec/data/enums_handler.rb
@@ -10,6 +10,7 @@ class Suit < T::Enum
     # The hearts suit
     Hearts = new
     Clubs = new('Clubs')
-    Diamonds = new
+    diamonds_serialized_value = 'Diamonds'
+    Diamonds = new(diamonds_serialized_value)
   end
 end

--- a/spec/data/enums_handler.rb
+++ b/spec/data/enums_handler.rb
@@ -3,9 +3,12 @@
 
 class Suit < T::Enum
   enums do
+    # The spades suit
+    # @see https://en.wikipedia.org/wiki/Spades_(suit)
     Spades = new
+    # The hearts suit
     Hearts = new
-    Clubs = new
+    Clubs = new('Clubs')
     Diamonds = new
   end
 end

--- a/spec/data/enums_handler.rb
+++ b/spec/data/enums_handler.rb
@@ -1,0 +1,11 @@
+# typed: true
+# frozen_string_literal: true
+
+class Suit < T::Enum
+  enums do
+    Spades = new
+    Hearts = new
+    Clubs = new
+    Diamonds = new
+  end
+end

--- a/spec/data/enums_handler.rb
+++ b/spec/data/enums_handler.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+# An enum representing card suits
 class Suit < T::Enum
   enums do
     # The spades suit

--- a/spec/yard_sorbet/enums_handler_spec.rb
+++ b/spec/yard_sorbet/enums_handler_spec.rb
@@ -1,0 +1,19 @@
+# typed: false
+# frozen_string_literal: true
+
+require 'yard'
+
+RSpec.describe YARDSorbet::EnumsHandler do
+  path = File.join(
+    File.expand_path('../data', __dir__),
+    'enums_handler.rb'
+  )
+
+  before do
+    YARD::Registry.clear
+    YARD::Parser::SourceParser.parse(path)
+  end
+
+  describe 'enums' do
+  end
+end

--- a/spec/yard_sorbet/enums_handler_spec.rb
+++ b/spec/yard_sorbet/enums_handler_spec.rb
@@ -14,6 +14,28 @@ RSpec.describe YARDSorbet::EnumsHandler do
     YARD::Parser::SourceParser.parse(path)
   end
 
-  describe 'enums' do
+  describe 'T::Enum subclass' do
+    it('registers constants') do
+      node = YARD::Registry.at('Suit')
+      expect(node.constants.size).to eq(4) # rubocop:disable Sorbet/ConstantsFromStrings
+    end
+
+    describe 'enums' do
+      it('attaches tags') do
+        node = YARD::Registry.at('Suit::Spades')
+        expect(node.tags.size).to eq(1)
+        expect(node.tags.first.tag_name).to eq('see')
+      end
+
+      it('attaches docstrings') do
+        node = YARD::Registry.at('Suit::Hearts')
+        expect(node.docstring).to eq('The hearts suit')
+      end
+
+      it('includes serialized value') do
+        node = YARD::Registry.at('Suit::Clubs')
+        expect(node.value).to eq("new('Clubs')")
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/dduugg/yard-sorbet/issues/43

Adds a simple `T::Enum` handler, which registers each enum as a constant. I don't love the formatting, but the content is clear enough:
![image](https://user-images.githubusercontent.com/697964/119405449-1f3ade00-bc96-11eb-8f9f-e06ed05d4264.png)

The collapsed view is decent though:
![image](https://user-images.githubusercontent.com/697964/119405524-3c6fac80-bc96-11eb-93bb-2badfcc083ed.png)
