### PR TITLE
Convert SigHandler to method handler

### DIFF
--- a/lib/yard-sorbet/handlers/sig_handler.rb
+++ b/lib/yard-sorbet/handlers/sig_handler.rb
@@ -4,7 +4,9 @@
 # A YARD Handler for Sorbet type declarations
 class YARDSorbet::Handlers::SigHandler < YARD::Handlers::Ruby::Base
   extend T::Sig
+
   handles method_call(:sig)
+  namespace_only
 
   # A struct that holds the parsed contents of a Sorbet type signature
   class ParsedSig < T::Struct

--- a/lib/yard-sorbet/handlers/sig_handler.rb
+++ b/lib/yard-sorbet/handlers/sig_handler.rb
@@ -18,23 +18,13 @@ class YARDSorbet::Handlers::SigHandler < YARD::Handlers::Ruby::Base
 
   private_constant :ParsedSig, :PARAM_EXCLUDES, :SIG_EXCLUDES
 
+  # Swap the method definition docstring and the sig docstring.
+  # Parse relevant parts of the +sig+ and include them as well.
   sig { void }
   def process
     method_node = YARDSorbet::NodeUtils.get_method_node(YARDSorbet::NodeUtils.sibling_node(statement))
-    process_method_definition(method_node, statement)
-  end
-
-  # Swap the method definition docstring and the sig docstring.
-  # Parse relevant parts of the +sig+ and include them as well.
-  sig do
-    params(
-      method_node: YARD::Parser::Ruby::AstNode,
-      sig_node: YARD::Parser::Ruby::MethodCallNode
-    ).void
-  end
-  private def process_method_definition(method_node, sig_node)
-    docstring, directives = YARDSorbet::Directives.extract_directives(sig_node.docstring)
-    parsed_sig = parse_sig(sig_node)
+    docstring, directives = YARDSorbet::Directives.extract_directives(statement.docstring)
+    parsed_sig = parse_sig(statement)
     enhance_tag(docstring, :abstract, parsed_sig)
     enhance_tag(docstring, :return, parsed_sig)
     if method_node.type != :command
@@ -44,7 +34,7 @@ class YARDSorbet::Handlers::SigHandler < YARD::Handlers::Ruby::Base
     end
     method_node.docstring = docstring.to_raw
     YARDSorbet::Directives.add_directives(method_node.docstring, directives)
-    sig_node.docstring = nil
+    statement.docstring = nil
   end
 
   sig { params(docstring: YARD::Docstring, name: String, types: T::Array[String]).void }

--- a/lib/yard-sorbet/node_utils.rb
+++ b/lib/yard-sorbet/node_utils.rb
@@ -50,7 +50,7 @@ module YARDSorbet::NodeUtils
   def self.sibling_node(node)
     siblings = node.parent.children
     siblings.each_with_index.find do |sibling, i|
-      if sibling == node
+      if sibling.equal?(node)
         return siblings.fetch(i + 1)
       end
     end

--- a/lib/yard-sorbet/node_utils.rb
+++ b/lib/yard-sorbet/node_utils.rb
@@ -36,10 +36,14 @@ module YARDSorbet::NodeUtils
   end
 
   # Gets the node that a sorbet `sig` can be attached do, bypassing visisbility modifiers and the like
-  sig { params(node: SIGABLE_NODE).returns(SIGABLE_NODE) }
+  sig { params(node: YARD::Parser::Ruby::AstNode).returns(SIGABLE_NODE) }
   def self.get_method_node(node)
-    return node if node.is_a?(YARD::Parser::Ruby::MethodDefinitionNode)
-    return node if ATTRIBUTE_METHODS.include?(node.method_name(true))
+    case node
+    when YARD::Parser::Ruby::MethodDefinitionNode
+      return node
+    when YARD::Parser::Ruby::MethodCallNode
+      return node if ATTRIBUTE_METHODS.include?(node.method_name(true))
+    end
 
     node.jump(:def, :defs)
   end


### PR DESCRIPTION
Converts `SigHandler` into a more intuitive `sig` `method_call` handler, eliminating some gnarly node traversal code.

I've verified the output on Homebrew (via https://github.com/Homebrew/rubydoc.brew.sh ) is unchanged with this PR. (It also ran 12% faster, though I have little confidence in that benchmark from a single run.)