### PR TITLE
Fix `sig` parsing of attr_* methods that use parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#52](https://github.com/dduugg/yard-sorbet/issues/52) Fix `sig` parsing of attr_* methods that use parens
+
 ## 0.5.0 (2021-05-28)
 
 ### New features

--- a/lib/yard-sorbet/handlers/sig_handler.rb
+++ b/lib/yard-sorbet/handlers/sig_handler.rb
@@ -15,12 +15,14 @@ class YARDSorbet::Handlers::SigHandler < YARD::Handlers::Ruby::Base
     prop :return, T.nilable(T::Array[String])
   end
 
+  # These node types attached to sigs represent attr_* declarations
+  ATTR_NODE_TYPES = T.let(%i[command fcall], T::Array[Symbol])
   # Skip these node types when parsing `sig` params
   PARAM_EXCLUDES = T.let(%i[array call hash].freeze, T::Array[Symbol])
   # Skip these node types when parsing `sig`s
   SIG_EXCLUDES = T.let(%i[array hash].freeze, T::Array[Symbol])
 
-  private_constant :ParsedSig, :PARAM_EXCLUDES, :SIG_EXCLUDES
+  private_constant :ParsedSig, :ATTR_NODE_TYPES, :PARAM_EXCLUDES, :SIG_EXCLUDES
 
   # Swap the method definition docstring and the sig docstring.
   # Parse relevant parts of the `sig` and include them as well.
@@ -31,7 +33,7 @@ class YARDSorbet::Handlers::SigHandler < YARD::Handlers::Ruby::Base
     parsed_sig = parse_sig(statement)
     enhance_tag(docstring, :abstract, parsed_sig)
     enhance_tag(docstring, :return, parsed_sig)
-    if method_node.type != :command
+    unless ATTR_NODE_TYPES.include?(method_node.type)
       parsed_sig.params.each do |name, types|
         enhance_param(docstring, name, types)
       end

--- a/lib/yard-sorbet/handlers/struct_handler.rb
+++ b/lib/yard-sorbet/handlers/struct_handler.rb
@@ -57,7 +57,7 @@ end
 # Class-level handler that folds all `const` and `prop` declarations into the constructor documentation
 # this needs to be injected as a module otherwise the default Class handler will overwrite documentation
 #
-# @note this modules is included in `YARD::Handlers::Ruby::ClassHandler`
+# @note this module is included in `YARD::Handlers::Ruby::ClassHandler`
 module YARDSorbet::Handlers::StructClassHandler
   extend T::Sig
 

--- a/spec/data/sig_handler.rb
+++ b/spec/data/sig_handler.rb
@@ -295,6 +295,9 @@ class AttrSigs
 
   sig {params(my_writer: T.nilable(Symbol)).returns(T.nilable(Symbol))}
   attr_writer :my_writer
+
+  sig {params(with_parens: T::Boolean).returns(T::Boolean)}
+  attr_writer(:with_parens)
 end
 
 class SigInlineVisibility

--- a/spec/yard_sorbet/handlers/sig_handler_spec.rb
+++ b/spec/yard_sorbet/handlers/sig_handler_spec.rb
@@ -368,5 +368,10 @@ RSpec.describe YARDSorbet::Handlers::SigHandler do
       node = YARD::Registry.at('AttrSigs#my_writer=')
       expect(node.tag(:return).types).to eq(%w[Symbol nil])
     end
+
+    it 'handles parens' do
+      node = YARD::Registry.at('AttrSigs#with_parens=')
+      expect(node.tag(:return).types).to eq(%w[Boolean])
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/dduugg/yard-sorbet/issues/52

Looks like the use of parens changes the node type of an `attr_` declaration 🤷 