### PR TITLE
Simplify sig parsing

### DIFF
--- a/lib/yard-sorbet/handlers/enums_handler.rb
+++ b/lib/yard-sorbet/handlers/enums_handler.rb
@@ -23,6 +23,6 @@ class YARDSorbet::Handlers::EnumsHandler < YARD::Handlers::Ruby::Base
 
   sig { params(node: YARD::Parser::Ruby::AstNode).returns(T::Boolean) }
   private def const_assign_node?(node)
-    node.type == :assign && node.children.first.children.first.type == :const
+    node.type == :assign && node[0][0].type == :const
   end
 end

--- a/lib/yard-sorbet/node_utils.rb
+++ b/lib/yard-sorbet/node_utils.rb
@@ -19,19 +19,16 @@ module YARDSorbet::NodeUtils
   sig do
     params(
       node: YARD::Parser::Ruby::AstNode,
-      exclude: T::Array[Symbol],
       _blk: T.proc.params(n: YARD::Parser::Ruby::AstNode).void
     ).void
   end
-  def self.bfs_traverse(node, exclude: [], &_blk)
+  def self.bfs_traverse(node, &_blk)
     queue = [node]
     until queue.empty?
       n = T.must(queue.shift)
       yield n
       n.children.each do |c|
-        unless exclude.include?(c.type)
-          queue.push(c)
-        end
+        queue.push(c)
       end
     end
   end


### PR DESCRIPTION
We don't need to do a full BFS traversal to find the `sig` `param` types, they're always at the same depth.