### PR TITLE
Bump required ruby version to `>= 2.6.0`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', head]
-    continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == '2.5' }}
+        ruby-version: ['2.6', '2.7', '3.0', head]
+    continue-on-error: ${{ matrix.ruby == 'head' }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
     - '**/*.rbi'  # VSCode plugin workaround
     - 'spec/data/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Layout/ClassStructure:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Bump required ruby version to `>= 2.6.0`
+
 ## 0.5.1 (2021-06-08)
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # yard-sorbet
 [![Gem Version](https://badge.fury.io/rb/yard-sorbet.svg)](https://badge.fury.io/rb/yard-sorbet)
-[![Build Status](https://travis-ci.com/dduugg/yard-sorbet.svg?branch=master)](https://travis-ci.com/dduugg/yard-sorbet)
+[![Build Status](https://github.com/dduugg/yard-sorbet/actions/workflows/ruby.yml/badge.svg)](https://github.com/dduugg/yard-sorbet/actions/workflows/ruby.yml)
 [![codecov](https://codecov.io/gh/dduugg/yard-sorbet/branch/master/graph/badge.svg)](https://codecov.io/gh/dduugg/yard-sorbet)
 
 A YARD [plugin](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md#Plugin_Support) that parses Sorbet type annotations

--- a/yard-sorbet.gemspec
+++ b/yard-sorbet.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     A YARD plugin that incorporates Sorbet type information
   DESC
   spec.homepage = 'https://github.com/dduugg/yard-sorbet'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   spec.metadata = {
     'bug_tracker_uri' => "#{spec.homepage}/issues",


### PR DESCRIPTION
Ruby 2.5 hasn't been officially [supported](https://sorbet.org/docs/faq#what-platforms-does-sorbet-support) by sorbet, and `sorbet-runtime` now [uses](https://github.com/sorbet/sorbet/pull/4252/files#r649491081) Ruby 2.6 features that break older versions.

(If we find we need to support 2.5, we could add it to a matrix that uses a different `Gemfile`, pinned to a version of sorbet that works in ruby 2.5.)