### PR TITLE
Fix parsing of `list` nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Bug fixes
 
 * [#61](https://github.com/dduugg/yard-sorbet/pull/61) Fix parsing of `sig` with nested return types
-* [#62](https://github.com/dduugg/yard-sorbet/pull/61) Fix parsing of `top_const_ref` nodes (e.g. `::Foo`)
+* [#63](https://github.com/dduugg/yard-sorbet/pull/63) Fix parsing of `top_const_ref` nodes (e.g. `::Foo`)
+* [#64](https://github.com/dduugg/yard-sorbet/pull/64) Fix parsing of `list` nodes
 
 ### Changes
 

--- a/spec/data/sig_handler.rb
+++ b/spec/data/sig_handler.rb
@@ -135,6 +135,9 @@ class SigReturn
   sig {void}
   def self.class_method_definition_contains_comment # rubocop:disable ...
   end
+
+  sig {returns Integer}
+  def no_parens; end
 end
 
 class SigAbstract

--- a/spec/yard_sorbet/handlers/sig_handler_spec.rb
+++ b/spec/yard_sorbet/handlers/sig_handler_spec.rb
@@ -353,6 +353,11 @@ RSpec.describe YARDSorbet::Handlers::SigHandler do
       block_param_node = node.tags.find { |t| t.name == 'block' }
       expect(block_param_node.types).to eq(['T.proc.params(arg0: T.all(String, PageWithURL)).returns(T.untyped)'])
     end
+
+    it 'handles omitting parens' do
+      node = YARD::Registry.at('SigReturn#no_parens')
+      expect(node.tag(:return).types).to eq(['Integer'])
+    end
   end
 
   describe 'attributes' do


### PR DESCRIPTION
These are seen when a `sig` method omits parens, e.g. `sig { returns Integer }`