### PR TITLE
Allow Ruby 2.5 again

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
     - '**/*.rbi'  # VSCode plugin workaround
     - 'spec/data/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
 
 Layout/ClassStructure:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@
 * [#64](https://github.com/dduugg/yard-sorbet/pull/64) Fix parsing of `list` nodes
 * [#65](https://github.com/dduugg/yard-sorbet/pull/65) Fix parsing of nested `array` nodes
 
-### Changes
-
-* Bump required ruby version to `>= 2.6.0`
-
 ## 0.5.1 (2021-06-08)
 
 ### Bug fixes

--- a/yard-sorbet.gemspec
+++ b/yard-sorbet.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     A YARD plugin that incorporates Sorbet type information
   DESC
   spec.homepage = 'https://github.com/dduugg/yard-sorbet'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
   spec.metadata = {
     'bug_tracker_uri' => "#{spec.homepage}/issues",


### PR DESCRIPTION
Upstream dependency was patched to restore 2.5 compatibility: https://github.com/sorbet/sorbet/pull/4281