### PR TITLE
Fix `T::Struct` constructor object creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main (unreleased)
 
+### Bug fixes
+
+* [#71](https://github.com/dduugg/yard-sorbet/pull/71) Fix `T::Struct` constructor object creation
+
 ## 0.5.2 (2021-07-01)
 
 ### Bug fixes

--- a/lib/yard-sorbet/handlers/struct_class_handler.rb
+++ b/lib/yard-sorbet/handlers/struct_class_handler.rb
@@ -33,12 +33,12 @@ module YARDSorbet
         # There is a chance that there is a custom initializer, so make sure we steal the existing docstring
         # and source
         docstring, directives = Directives.extract_directives(object.docstring)
+        # These should probably check for existing tags, and merge with any existing documentation:
         props.each do |prop|
           docstring.add_tag(YARD::Tags::Tag.new(:param, prop.doc, prop.types, prop.prop_name))
         end
-        docstring.add_tag(YARD::Tags::Tag.new(:return, '', class_ns))
+        docstring.add_tag(YARD::Tags::Tag.new(:return, '', 'void'))
         decorate_t_struct_init(object, props, docstring, directives)
-        register(object)
       end
 
       sig do
@@ -54,7 +54,7 @@ module YARDSorbet
         object.parameters = to_object_parameters(props)
         # The "source" of our constructor is the field declarations
         object.source ||= props.map(&:source).join("\n")
-        object.docstring = docstring.to_raw
+        object.docstring = docstring
         Directives.add_directives(object.docstring, directives)
       end
 

--- a/lib/yard-sorbet/tag_utils.rb
+++ b/lib/yard-sorbet/tag_utils.rb
@@ -34,7 +34,7 @@ module YARDSorbet
       params(docstring: YARD::Docstring, tag_name: String, name: T.nilable(String))
         .returns(T.nilable(YARD::Tags::Tag))
     end
-    private_class_method def self.find_tag(docstring, tag_name, name)
+    def self.find_tag(docstring, tag_name, name)
       docstring.tags.find { |t| t.tag_name == tag_name && t.name == name }
     end
   end

--- a/spec/yard_sorbet/handlers/struct_class_handler_spec.rb
+++ b/spec/yard_sorbet/handlers/struct_class_handler_spec.rb
@@ -10,11 +10,21 @@ RSpec.describe YARDSorbet::Handlers::StructClassHandler do
   end
 
   describe 'constructor' do
-    it 'has the appropriate parameters' do
+    it 'has the parameter tag type' do
       node = YARD::Registry.at('PersonStruct#initialize')
-      expect(node.parameters).to eq(
-        [['name:', nil], ['age:', nil], ['optional:', 'nil'], ['writable:', nil], ['mystery:', nil]]
-      )
+      tag = YARDSorbet::TagUtils.find_tag(node.docstring, 'param', 'name')
+      expect(tag&.types).to eq(['String'])
+    end
+
+    it 'has the nilable parameter tag type' do
+      node = YARD::Registry.at('PersonStruct#initialize')
+      tag = YARDSorbet::TagUtils.find_tag(node.docstring, 'param', 'optional')
+      expect(tag&.types).to eq(%w[String nil])
+    end
+
+    it 'return tag has type annotation' do
+      node = YARD::Registry.at('PersonStruct#initialize')
+      expect(node.tag(:return).type).to eq('void')
     end
 
     it 'uses the docstring from an explicit initializer' do
@@ -22,9 +32,16 @@ RSpec.describe YARDSorbet::Handlers::StructClassHandler do
       expect(node.docstring).to eq('This is a special intializer')
     end
 
-    it 'handles exceptional prop names' do
+    it 'handles keyword node prop names' do
       node = YARD::Registry.at('ExceptionalPersonStruct#initialize')
-      expect(node.parameters).to eq([['end:', nil], ['Foo:', nil]])
+      tag = YARDSorbet::TagUtils.find_tag(node.docstring, 'param', 'end')
+      expect(tag&.types).to eq(['String'])
+    end
+
+    it 'handles const node prop names' do
+      node = YARD::Registry.at('ExceptionalPersonStruct#initialize')
+      tag = YARDSorbet::TagUtils.find_tag(node.docstring, 'param', 'Foo')
+      expect(tag&.types).to eq(['String'])
     end
   end
 end


### PR DESCRIPTION
Constructor `param` tags weren't appearing, also the docstring text was using the class docstring. This wasn't detected because the tests were only checking the node `parameters`, not the actual tags.

I've also changed the return type of the constructor to be `void` (`new` returns the namespace object, not `initialize`).

Before:

![image](https://user-images.githubusercontent.com/697964/126074173-8267812f-9872-4755-b707-cd03eec98bd1.png)

After:

![image](https://user-images.githubusercontent.com/697964/126074188-407d9a89-eed9-4032-90e1-f5e8e3a00260.png)
