### PR TITLE
Configure Dependabot updates to be weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 10
     labels:
       - "automerge"


### PR DESCRIPTION
Given sorbet releases a new version daily and this repo doesn't require
daily updates we can bump weekly to reduce noise.

Let me know if you disagree I don't have context from when this was introduced.