### PR TITLE
Prefer statement docstring when processing registered node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+### Bug Fixes
+
+* [#201](https://github.com/dduugg/yard-sorbet/issues/201) Caching not reloading docstring when using Sorbet signature
+
 ## 0.8.0 (2023-01-14)
 
 ### New Features

--- a/lib/yard-sorbet/handlers/sig_handler.rb
+++ b/lib/yard-sorbet/handlers/sig_handler.rb
@@ -37,7 +37,7 @@ module YARDSorbet
         separator = scope == :instance && def_node.type == :def ? '#' : '.'
         registered = YARD::Registry.at("#{namespace}#{separator}#{def_node.method_name(true)}")
         if registered
-          parse_node(registered, registered.docstring)
+          parse_node(registered, statement.docstring || registered.docstring)
           # Since we're probably in an RBI file, delete the def node, which could otherwise erroneously override the
           # visibility setting
           NodeUtils.delete_node(def_node)

--- a/spec/data/sig_handler.rbi.txt
+++ b/spec/data/sig_handler.rbi.txt
@@ -20,5 +20,9 @@ module Merge
 
     sig { returns(Integer) }
     def bat; end
+
+    # new docstring
+    sig { returns(T::Boolean) }
+    def xyz; end
   end
 end

--- a/spec/data/sig_handler.txt
+++ b/spec/data/sig_handler.txt
@@ -357,5 +357,8 @@ module Merge
 
     # @return the result
     def bat; end
+
+    # old doctsring
+    def xyz; end
   end
 end

--- a/spec/yard_sorbet/handlers/sig_handler_spec.rb
+++ b/spec/yard_sorbet/handlers/sig_handler_spec.rb
@@ -63,6 +63,10 @@ RSpec.describe YARDSorbet::Handlers::SigHandler do
     it 'merges return tag comment with sig return type' do
       expect(YARD::Registry.at('Merge::A#bat').tag(:return).text).to eq('the result')
     end
+
+    it 'overwrites the prior docstring when a new docstring exists' do
+      expect(YARD::Registry.at('Merge::A#xyz').docstring).to eq('new docstring')
+    end
   end
 
   describe 'attaching to method' do


### PR DESCRIPTION
Resolves https://github.com/dduugg/yard-sorbet/issues/201

Changes sig processing to prefer using the newer docstring, if one exists, if we find a registered node when processing a `sig`. This is to enable caching to work properly.

The thinking with the former approach was that when scanning rbi files, the original source code docstring is more likely to be the useful one when both exist. It's not clear that behavior is necessary. For instance, in looking at two rbi generation libraries, tapioca seems to include docstrings but not sigs, while parlour seems to include sigs but not docstrings.