### PR TITLE
Move optional T::Struct initializer arguments to end of list

### DIFF
--- a/lib/yard-sorbet/handlers/struct_class_handler.rb
+++ b/lib/yard-sorbet/handlers/struct_class_handler.rb
@@ -34,9 +34,18 @@ module YARDSorbet
         # and source
         docstring, directives = Directives.extract_directives(object.docstring)
         object.tags.each { docstring.add_tag(_1) }
+        # ensure anything with a default is after everything which is
+        # required, per Ruby method signature requirements.
+        sorted_props = props.sort_by do |prop|
+          if !prop.default.nil? || prop.types.include?('nil')
+            1
+          else
+            0
+          end
+        end
         props.each { TagUtils.upsert_tag(docstring, 'param', _1.types, _1.prop_name, _1.doc) }
         TagUtils.upsert_tag(docstring, 'return', TagUtils::VOID_RETURN_TYPE)
-        decorate_t_struct_init(object, props, docstring, directives)
+        decorate_t_struct_init(object, sorted_props, docstring, directives)
       end
 
       sig do

--- a/spec/yard_sorbet/handlers/struct_class_handler_spec.rb
+++ b/spec/yard_sorbet/handlers/struct_class_handler_spec.rb
@@ -70,5 +70,10 @@ RSpec.describe YARDSorbet::Handlers::StructClassHandler do
       tag = YARDSorbet::TagUtils.find_tag(node.docstring, 'param', 'Foo')
       expect(tag&.types).to eq(['String'])
     end
+
+    it 'moves optional initializer arguments to end and leaves others in place' do
+      node = YARD::Registry.at('PersonStruct#initialize')
+      expect(node.parameters.map(&:first)).to eq(%w[name: age: writable: mystery: optional: not_mutable: ])
+    end
   end
 end


### PR DESCRIPTION
Ensures T::Struct initializer definitions don't generate invalid Ruby method signatures by placing an optional (defaulted) kwarg before a required kwarg.

Allows yard-sorbet output to be processed with external tools without errors.