### PR TITLE
Allow inline comments on sig parameters to be used in yard docs

### DIFF
--- a/lib/yard-sorbet/handlers/sig_handler.rb
+++ b/lib/yard-sorbet/handlers/sig_handler.rb
@@ -99,7 +99,7 @@ module YARDSorbet
         sibling[0][0].each do |param|
           param_name = param[0][0]
           types = SigToYARD.convert(param.last)
-          TagUtils.upsert_tag(docstring, 'param', types, param_name)
+          TagUtils.upsert_tag(docstring, 'param', types, param_name, param.docstring.to_s)
         end
       end
 

--- a/spec/data/sig_handler.txt
+++ b/spec/data/sig_handler.txt
@@ -176,6 +176,15 @@ class SigParams < A
   def blk_method(&blk); nil; end
 
   sig do
+    params(
+      first: String, # Some documentation for the first param
+      # Second param docstring
+      second: Rational
+    )
+  end
+  def inline_param_doc_method(first, second); end
+
+  sig do
     override
     .params(block: T.proc.params(
       model: EmailConversation,

--- a/spec/yard_sorbet/handlers/sig_handler_spec.rb
+++ b/spec/yard_sorbet/handlers/sig_handler_spec.rb
@@ -233,6 +233,16 @@ RSpec.describe YARDSorbet::Handlers::SigHandler do
       expect(blk_tag.types).to eq(['T.proc.params(arg0: String).returns(T::Array[Hash])'])
     end
 
+    it 'parses inline docstrings for params' do
+      inline = YARD::Registry.at('SigParams#inline_param_doc_method')
+      expect(inline.docstring.to_raw.rstrip).to eq(<<~TXT.rstrip)
+        @param [String] first
+          Some documentation for the first param
+        @param [Rational] second
+          Second param docstring
+      TXT
+    end
+
     it 'parses return type of method with block param' do
       expect(YARD::Registry.at('SigParams#blk_method').tag(:return).types).to eq(['nil'])
     end

--- a/spec/yard_sorbet/handlers/sig_handler_spec.rb
+++ b/spec/yard_sorbet/handlers/sig_handler_spec.rb
@@ -235,12 +235,10 @@ RSpec.describe YARDSorbet::Handlers::SigHandler do
 
     it 'parses inline docstrings for params' do
       inline = YARD::Registry.at('SigParams#inline_param_doc_method')
-      expect(inline.docstring.to_raw.rstrip).to eq(<<~TXT.rstrip)
-        @param [String] first
-          Some documentation for the first param
-        @param [Rational] second
-          Second param docstring
-      TXT
+      expect(inline.docstring.all).to eq(
+        "@param [String] first\n  Some documentation for the first param\n" \
+        "@param [Rational] second\n  Second param docstring"
+      )
     end
 
     it 'parses return type of method with block param' do


### PR DESCRIPTION
A feature that has been useful for documenting parameters inline, given how _verbose_ Sorbet can be 🤕 

An example for a piece of a contrived rules engine DSL:

```rb
sig do
  params(
    query: Query. # Query object that is uesd to gather facts about the context, to check against for conditions
    # Execution block in which conditions based on facts from the query can lead to a decision and an action
    decider: T.bind(ExecutionContext).params(cond: CondScope).returns(T.any(Decision, Deferral))  
  ).returns(T.all(Querier, Actor)
end
```

Thses changes would include those comments as part of the YARD docstring, as documentation for the parameter.