### PR TITLE
Restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/publish-to-github-pages.yml
+++ b/.github/workflows/publish-to-github-pages.yml
@@ -4,6 +4,8 @@ name: Publish Docs to GitHub Pages
   push:
     branches:
       - main
+permissions:
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,6 +5,8 @@ name: Ruby
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
 jobs:
   Ruby-CI:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves the two open [code scanning alerts](https://github.com/dduugg/yard-sorbet/security/code-scanning) (`actions/missing-workflow-permissions`): neither workflow limited the permissions of the default `GITHUB_TOKEN`.

- **ruby.yml** — CI only reads the repo, so `contents: read`.
- **publish-to-github-pages.yml** — deploys via `peaceiris/actions-gh-pages`, which pushes to the `gh-pages` branch, so `contents: write`.

https://claude.ai/code/session_018zt2bzguHQ6LyUNDQf6CTd